### PR TITLE
Add ShellService for configuration parameters of Spoofax REPL

### DIFF
--- a/org.metaborg.meta.lang.esv/syntax/EditorService.sdf3
+++ b/org.metaborg.meta.lang.esv/syntax/EditorService.sdf3
@@ -13,6 +13,7 @@ imports
   RefactoringsService	
   RecoveryRules	
   MenusService	
+  ShellService
   Views
 
 context-free start-symbols

--- a/org.metaborg.meta.lang.esv/syntax/ShellService.sdf3
+++ b/org.metaborg.meta.lang.esv/syntax/ShellService.sdf3
@@ -1,0 +1,11 @@
+module ShellService
+
+imports
+
+  Common
+  SemanticServices
+
+context-free syntax
+	Section.Shell = <shell <ShellProperty*>>
+	ShellProperty.EvaluationMethod = <evaluation method : <String>>
+	ShellProperty.ShellStartSymbol = <shell start symbol : <Sort>>


### PR DESCRIPTION
This adds the configuration properties that are currently needed:
- Evaluation method (currently only "dynsem" is supported).
- The start symbol that is used by the REPL when parsing.
