### PR TITLE
Add option for old imploder implemented in Stratego

### DIFF
--- a/org.metaborg.meta.lang.esv/syntax/LanguageDescription.sdf3
+++ b/org.metaborg.meta.lang.esv/syntax/LanguageDescription.sdf3
@@ -35,6 +35,7 @@ context-free syntax
   LanguageProperty.Description = <description : <PropertyValue>> 
   LanguageProperty.Table = <table : <PropertyValue>> 
   LanguageProperty.TableProvider = <table provider : <StrategoCall>> 
+  LanguageProperty.Imploder = <imploder : <ImploderSetting>>
   LanguageProperty.StartSymbols = <start symbols : <Sort*>> 
   LanguageProperty.StartSymbols = <start symbols : <PropertyValues>> {avoid}
   LanguageProperty.Parser = <parser : <PropertyValue>>
@@ -48,6 +49,8 @@ context-free syntax
   LanguageProperty.SemanticProvider = <provider : <PropertyValue>> 
   LanguageProperty.LanguageIncludes = <<PropertyValue> includes : <PropertyValues>> 
   LanguageProperty.LanguageSources = <<PropertyValue> sources : <PropertyValues>>
+  ImploderSetting.Java = <java>
+  ImploderSetting.Stratego = <stratego>
   ContextType.None = <none>
   ContextType.Legacy = <legacy>
   ContextType.TaskEngine = <taskengine> 


### PR DESCRIPTION
I've added an imploder setting to ESV and to Spoofax Core to be able to select the old Stratego implementation of the imploder which takes an AsFix2 parse tree and yields an AST. This is the imploder used in the Stratego compiler, and the _only_ imploder that currently handles mix-syntax correctly. 

See also: https://github.com/metaborg/spoofax/pull/40